### PR TITLE
Ajustar paddings del navbar y corregir uso de variables de color

### DIFF
--- a/src/components/Activities.astro
+++ b/src/components/Activities.astro
@@ -16,7 +16,7 @@ import Section from '@/components/Section.astro'
     </h2>
 
     <div
-      class="mx-auto mt-64 flex flex-col font-bebas text-4xl text-[var(--color-secondary)] md:mt-64 md:flex-row md:justify-center md:items-start md:gap-x-32 space-y-2 md:text-4xl lg:text-5xl max-w-5xl"
+      class="mx-auto mt-64 flex flex-col font-bebas text-4xl text-secondary md:mt-64 md:flex-row md:justify-center md:items-start md:gap-x-32 space-y-2 md:text-4xl lg:text-5xl max-w-5xl"
       aria-labelledby="titulo-actividades"
     >
       <ul class="space-y-2 text-center md:text-left md:w-max" role="list">

--- a/src/components/How.astro
+++ b/src/components/How.astro
@@ -12,13 +12,13 @@ import HowImage from '@/assets/sofia-surferss-snorkel.webp'
     <div class="h-full w-full justify-between flex items-start">
       <div class="flex flex-col items-start justify-start">
         <span
-          class="font-bebas md:w-[483px] md:text-4xl text-2xl text-[#202C38]"
+          class="font-bebas md:w-[483px] md:text-4xl text-2xl text-secondary"
         >
           ¿CÓMO PUEDO IR?
         </span>
 
         <span
-          class="font-bebas md:w-[483px] md:text-5xl md:mr-5 text-3xl text-[#202C38] mt-10"
+          class="font-bebas md:w-[483px] md:text-5xl md:mr-5 text-3xl text-secondary mt-10"
         >
           Un viaje exclusivo al que solo se podrá acceder a través de las marcas
           Embajadoras de Surferss Wave

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -7,7 +7,7 @@ const navItems = [
 ]
 ---
 
-<nav class="relative top-0 left-0 right-0 font-bebas pt-10">
+<nav class="relative top-0 left-0 right-0 font-bebas">
   <div
     class="max-w-7xl mx-auto flex justify-around items-center px-6 lg:px-8 relative pt-12"
   >
@@ -20,8 +20,7 @@ const navItems = [
           <a
             href={item.href}
             class={`
-              text-xl font-bebas transition-all duration-300 py-2 px-4 text-[#79c7ad] hover:bg-[#79c7ad] hover:text-white
-              rounded-full 
+              text-xl font-bebas transition-all duration-300 py-1 px-4 pb-0.5 text-primary hover:bg-primary rounded-full hover:text-white
             `}
           >
             {item.text}
@@ -55,7 +54,7 @@ const navItems = [
           <a
             href={item.href}
             class={`
-              text-xl font-bebas transition-all duration-300 py-1 px-4 text-[#79c7ad] hover:bg-[#79c7ad] rounded-full hover:text-white
+              text-xl font-bebas transition-all duration-300 py-1 px-4 pb-0.5 text-primary hover:bg-primary rounded-full hover:text-white
             `}
           >
             {item.text}

--- a/src/components/WhatIncludes.astro
+++ b/src/components/WhatIncludes.astro
@@ -7,11 +7,11 @@ import Section from '@/components/Section.astro'
   class="bg-[url('../assets/section-includes-bg.webp')]"
 >
   <div class=`flex justify-center w-full flex-col  items-end`>
-    <span class="font-bebas md:text-4xl text-2xl text-[#202C38]">
+    <span class="font-bebas md:text-4xl text-2xl text-secondary">
       ¿que incluye?
     </span>
     <span
-      class="font-bebas lg:text-5xl text-3xl md:text-5xl text-[#202C38] mt-7 text-right"
+      class="font-bebas lg:text-5xl text-3xl md:text-5xl text-secondary mt-7 text-right"
     >
       alojamiento
       <br />
@@ -21,7 +21,7 @@ import Section from '@/components/Section.astro'
       <br />
       actividades
     </span>
-    <span class="font-bebas md:text-4xl text-1xl mt-7 text-[#202C38]">
+    <span class="font-bebas md:text-4xl text-1xl mt-7 text-secondary">
       *desplazamiento no incluido
     </span>
   </div>


### PR DESCRIPTION
Se ajusta el padding de los ítems del navbar y el margin-top general para alinearse con el diseño de Figma.
También se hace uso de las variables de color utilizando text-primary y text-secondary.

Cambios visuales sin impacto funcional.

<img width="1331" height="146" alt="imagen" src="https://github.com/user-attachments/assets/a1bc51b2-a89c-4059-8e80-45dcb2227763" />
