### PR TITLE
fix: ajustes de estructura y diseño responsive en layout, index y sec…

### DIFF
--- a/src/components/How.astro
+++ b/src/components/How.astro
@@ -4,12 +4,11 @@ import Section from '@/components/Section.astro'
 import HowImage from '@/assets/sofia-surferss-snorkel.webp'
 ---
 
-<Section
-  id="como-ir"
-  class="bg-[url('../assets/section-how-bg.webp')] bg-cover"
->
-  <div class="md:flex w-full h-full md:items-center flex-col lg:flex-row">
-    <div class="h-full w-full justify-between flex items-start">
+<Section id="como-ir" class="bg-[url('../assets/section-how-bg.webp')]">
+  <div
+    class="md:flex w-full md:items-center flex-col lg:flex-row min-h-[500px] md:min-h-[600px] lg:min-h-[700px]"
+  >
+    <div class="justify-between flex items-start">
       <div class="flex flex-col items-start justify-start">
         <span
           class="font-bebas md:w-[483px] md:text-4xl text-2xl text-secondary"

--- a/src/components/Where.astro
+++ b/src/components/Where.astro
@@ -1,75 +1,14 @@
 ---
-import { Image } from 'astro:assets'
-import WhereBg from '@/assets/section-where-bg.webp'
-import SurfersWave from '@/assets/surferss-wave.svg'
+import Section from '@/components/Section.astro'
 ---
 
-<section
-  id="donde-es"
-  aria-labelledby="donde-es-heading"
-  class="relative w-full -z-10 text-center items-center text-white mt-14 -mb-44"
->
-  <!-- Versión MOBILE -->
-  <div class="block md:hidden relative h-[400px] overflow-visible">
-    <div class="relative w-full h-full scale-[1.4] origin-center transform">
-      <img
-        src={SurfersWave.src}
-        alt=""
-        role="presentation"
-        aria-hidden="true"
-        class="absolute top-5 right-2 w-full z-10 pointer-events-none scale-[1.5]"
-      />
-
-      <Image
-        src={WhereBg}
-        alt="Grupo de surfistas reunidxs sobre sus tablas en el mar"
-        class="w-full h-full object-cover mt-20"
-        loading="eager"
-      />
-    </div>
-  </div>
-
-  <!-- Versión DESKTOP -->
-  <div class="hidden md:block relative">
-    <img
-      src={SurfersWave.src}
-      alt=""
-      role="presentation"
-      aria-hidden="true"
-      class="absolute top-0 left-0 w-full z-10 mt-7"
-    />
-
-    <Image
-      src={WhereBg}
-      alt="Grupo de surfistas reunidxs sobre sus tablas en el mar"
-      class="w-full h-auto"
-      loading="eager"
-    />
-  </div>
-
+<Section id="donde-es" class="bg-[url('../assets/section-where-bg.webp')]">
   <div
-    class="absolute inset-0 z-30 flex items-center justify-center font-bebas"
+    class="flex justify-center w-full flex-col items-center text-white min-h-[500px] md:min-h-[600px] lg:min-h-[700px]"
   >
-    <h2
-      id="donde-es-heading"
-      class="text-xl md:text-4xl lg:text-5xl text-center mt-20 sm:mt-0"
-    >
-      ¿DÓNDE ES?
-    </h2>
-  </div>
-
-  <div
-    class="absolute bottom-10 sm:bottom-10 md:bottom-16 lg:bottom-64 left-0 right-0 flex justify-center font-bebas"
-  >
-    <p
-      class="text-3xl sm:text-4xl md:text-4xl lg:text-6xl tracking-wide text-center"
-    >
-      SOMO, CANTABRIA – LATAS SURF HOUSE
+    <h2 class="text-2xl md:text-3xl lg:text-4xl font-bebas">¿DÓNDE ES?</h2>
+    <p class="text-4xl md:text-5xl lg:text-6xl font-bebas">
+      SOMO, CANTABRIA - LATAS SURF HOUSE
     </p>
   </div>
-
-  <div
-    class="bg-[url('../assets/separator.webp')] absolute bottom-0 left-0 right-0 bg-center bg-cover h-[196px]"
-  >
-  </div>
-</section>
+</Section>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Analytics from '@vercel/analytics/astro'
 import Footer from '@/components/Footer.astro'
+import Navbar from '@/components/Navbar.astro'
 
 import '@fontsource/bebas-neue'
 
@@ -97,9 +98,12 @@ const structuredData = {
       set:html={JSON.stringify(structuredData)}
     />
   </head>
-  <body class="text-gray-800 min-h-screen pb-24">
-    <slot />
-    <Analytics />
+  <body>
+    <Navbar />
+    <main class="flex flex-col mx-auto w-full">
+      <slot />
+      <Analytics />
+    </main>
     <Footer />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '@/layouts/Layout.astro'
-import Navbar from '@/components/Navbar.astro'
 import Hero from '@/components/Hero.astro'
 import How from '@/components/How.astro'
 import Where from '@/components/Where.astro'
@@ -12,12 +11,9 @@ import Activities from '@/components/Activities.astro'
   title="Surferss Wave - Viaja con Sofía a una experiencia única de surf"
   description="Viaje exclusivo al que solo se podrá acceder a través de las marcas Embajadoras de Surferss Wave. Surf, diversión, playa, fiestas y actividades con Sofía."
 >
-  <main class="w-full">
-    <Navbar />
-    <Hero />
-    <Where />
-    <How />
-    <WhatIncludes />
-    <Activities />
-  </main>
+  <Hero />
+  <Where />
+  <How />
+  <WhatIncludes />
+  <Activities />
 </Layout>


### PR DESCRIPTION
Este PR incluye una serie de ajustes centrados en mejorar la estructura general del layout y solucionar problemas visuales en versión responsive.

Cambios realizados:

- Se eliminó el <Navbar /> y el <main> de index.astro, ya que ambos están ahora correctamente definidos dentro del Layout.
- Se añadió el <main> y el <Navbar /> directamente en Layout.astro, manteniendo una estructura semántica clara.
- Se corrigió el diseño de las secciones How.astro y Where.astro, igualando sus alturas mínimas (min-h) para alinear correctamente las olas de fondo entre secciones adyacentes.
- En Where.astro, se eliminó todo el contenido anterior y se dejó una estructura mínima limpia. Solo se conserva el fondo, la clase base y la altura mínima. Los ajustes de contenido y SVG decorativos se harán en una rama aparte más adelante.

Estos cambios establecen una base visual y estructural más sólida para seguir aplicando modificaciones específicas en futuras ramas.

<img width="1855" height="898" alt="imagen" src="https://github.com/user-attachments/assets/80f3d1aa-1339-4fb5-b006-7e897fffa9ce" />

