### PR TITLE
Fix: eliminado mt-10 del menú móvil para eliminar espacio debajo de nav

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -8,7 +8,7 @@ const navItems = [
 ---
 
 <nav
-  class="fixed top-0 left-0 right-0 z-50 font-bebas transition-all duration-300 border-b border-transparent pt-2"
+  class="fixed top-0 left-0 right-0 z-50 font-bebas transition-all duration-300 border-b border-transparent pt-2 bg-white"
 >
   <div
     class="max-w-7xl mx-auto flex justify-around items-center py-10 md:py-8 lg:py-8 relative"
@@ -84,7 +84,7 @@ const navItems = [
 
   <!-- Menú móvil -->
   <div
-    class="hidden md:hidden absolute top-full left-0 right-0 w-full bg-opacity-95 bg-white shadow-lg z-50 mt-10"
+    class="hidden md:hidden absolute top-full left-0 right-0 w-full bg-opacity-95 bg-white shadow-lg z-50"
     id="mobile-menu"
   >
     <div class="px-4 pt-4 pb-5 space-y-3 max-w-md mx-auto">


### PR DESCRIPTION
Este PR corrige un problema visual en la versión responsive del menú de navegación. Anteriormente, al desplegar el menú hamburguesa, aparecía un espacio de 40px debajo de la etiqueta <nav>.

Se ha eliminado la clase `mt-10` del div con id `mobile-menu`, lo que elimina el margen superior innecesario y mejora el aspecto visual del menú en dispositivos móviles.

### Cambios realizados:
- Eliminada clase `mt-10` en el div `#mobile-menu`.

### Resultado:
- El menú móvil ahora se despliega sin dejar un espacio visual debajo del nav.

<img width="308" height="325" alt="menu_espacio" src="https://github.com/user-attachments/assets/e5890894-deae-48f6-94b7-943d594315ff" />

<img width="311" height="280" alt="menu_sin_espacio" src="https://github.com/user-attachments/assets/a808d866-53b9-4003-9173-54d7f41888fc" />
