### PR TITLE
Fix: ajusta posición del logo en versión móvil

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -26,7 +26,7 @@ import HeroImage from '@/assets/sofia-surferss-hero.png'
         alt=""
         role="presentation"
         aria-hidden="true"
-        class="absolute -bottom-20 -right-5 w-[155px] h-[156px] md:hidden rotate-[40deg]"
+        class="absolute -bottom-44 -right-[-50px] w-[155px] h-[156px] md:hidden rotate-[40deg]"
         width="196"
         height="200"
         id="mobile-hero-logo"
@@ -48,7 +48,7 @@ import HeroImage from '@/assets/sofia-surferss-hero.png'
         height="256"
       />
 
-      <div class="flex flex-col gap-4 mt-20 md:mt-0">
+      <div class="flex flex-col gap-4 mt-44 md:mt-0">
         <h1
           class="text-primary text-2xl md:text-3xl lg:text-5xl leading-tight font-bebas text-center"
         >

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -8,7 +8,7 @@ const navItems = [
 ---
 
 <nav
-  class="fixed top-0 left-0 right-0 z-50 font-bebas transition-all duration-300 border-b border-transparent pt-2"
+  class="fixed top-0 left-0 right-0 z-50 font-bebas transition-all duration-300 border-b border-transparent pt-2 bg-white"
 >
   <div
     class="max-w-7xl mx-auto flex justify-around items-center py-10 md:py-8 lg:py-8 relative"
@@ -84,7 +84,7 @@ const navItems = [
 
   <!-- Menú móvil -->
   <div
-    class="hidden md:hidden absolute top-full left-0 right-0 w-full bg-opacity-95 bg-white shadow-lg z-50 mt-10"
+    class="hidden md:hidden absolute top-full left-0 right-0 w-full bg-opacity-95 bg-white shadow-lg z-50"
     id="mobile-menu"
   >
     <div class="px-4 pt-4 pb-5 space-y-3 max-w-md mx-auto">


### PR DESCRIPTION
Esta PR corrige la posición del logotipo en el diseño responsive.

El logo quedaba en la esquina inferior derecha, superpuesto con la imagen de Sofia y afectando a la estética general en pantallas pequeñas.

Ahora el logo queda centrado y por debajo de la imagen para mejorar la visibilidad y mantener una mejor armonía visual en la versión móvil.

<img width="383" height="708" alt="logo-before" src="https://github.com/user-attachments/assets/9603f32b-8e4a-4f38-9bec-8e4975b00815" />

<img width="400" height="777" alt="logo-after" src="https://github.com/user-attachments/assets/eb2d6478-4105-4e59-a0f3-59a284bba6d1" />
